### PR TITLE
Add Python todo list application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# tsi_individual_project2
+# Todo List Application
+
+This project contains a simple command line todo list application written in Python. It demonstrates inheritance, multi-level inheritance, and interface objects while persisting data to CSV files.
+
+## Usage
+
+Run the application using Python's `-m` option:
+
+```
+python3 -m todo list           # List all tasks
+python3 -m todo add "Title" --description "text" --due YYYY-MM-DDTHH:MM:SS
+python3 -m todo filter --completed
+python3 -m todo filter --title-contains text
+python3 -m todo done TASK_ID
+```
+
+Tasks are stored in `tasks.csv` in the current directory.

--- a/todo/__main__.py
+++ b/todo/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/todo/cli.py
+++ b/todo/cli.py
@@ -1,0 +1,60 @@
+import argparse
+from datetime import datetime
+
+from .manager import TodoManager
+from .storage import CSVTaskStorage
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Simple Todo Application")
+    subparsers = parser.add_subparsers(dest="command")
+
+    add_parser = subparsers.add_parser("add", help="Add a new task")
+    add_parser.add_argument("title")
+    add_parser.add_argument("--description", default="")
+    add_parser.add_argument("--due")
+
+    list_parser = subparsers.add_parser("list", help="List tasks")
+
+    filter_parser = subparsers.add_parser("filter", help="Filter tasks")
+    filter_parser.add_argument("--completed", action="store_true")
+    filter_parser.add_argument("--title-contains")
+
+    done_parser = subparsers.add_parser("done", help="Mark task complete")
+    done_parser.add_argument("task_id", type=int)
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    storage = CSVTaskStorage("tasks.csv")
+    manager = TodoManager(storage)
+    manager.load()
+
+    if args.command == "add":
+        due = datetime.fromisoformat(args.due) if args.due else None
+        manager.add_task(args.title, description=args.description, due_date=due)
+        manager.save()
+        print("Task added")
+    elif args.command == "list":
+        for task in manager.list_tasks():
+            print(task)
+    elif args.command == "filter":
+        predicate = lambda t: True
+        if args.completed:
+            predicate = lambda t: t.completed
+        if args.title_contains:
+            text = args.title_contains
+            predicate = lambda t, p=predicate: p(t) and text in t.title
+        for task in manager.filter_tasks(predicate):
+            print(task)
+    elif args.command == "done":
+        manager.mark_complete(args.task_id)
+        manager.save()
+        print("Task marked complete")
+    else:
+        print("No command specified")
+
+if __name__ == "__main__":
+    main()

--- a/todo/manager.py
+++ b/todo/manager.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+from typing import Callable, List
+from dataclasses import dataclass, field
+
+from .models import Task
+from .storage import StorageInterface, CSVTaskStorage
+
+class Filterable:
+    """Interface defining a filter method."""
+    def filter_tasks(self, predicate: Callable[[Task], bool]) -> List[Task]:
+        raise NotImplementedError
+
+@dataclass
+class TodoManager(Filterable):
+    storage: StorageInterface
+    tasks: List[Task] = field(default_factory=list)
+
+    def load(self) -> None:
+        self.tasks = self.storage.load_tasks()
+
+    def save(self) -> None:
+        self.storage.save_tasks(self.tasks)
+
+    def add_task(self, title: str, description: str = "", due_date=None) -> Task:
+        task_id = (max((t.id for t in self.tasks), default=0) + 1)
+        task = Task(id=task_id, title=title, description=description, due_date=due_date)
+        self.tasks.append(task)
+        return task
+
+    def mark_complete(self, task_id: int) -> None:
+        for t in self.tasks:
+            if t.id == task_id:
+                t.completed = True
+                break
+
+    def filter_tasks(self, predicate: Callable[[Task], bool]) -> List[Task]:
+        return [t for t in self.tasks if predicate(t)]
+
+    def list_tasks(self) -> List[Task]:
+        return self.tasks

--- a/todo/models.py
+++ b/todo/models.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional, Dict
+
+@dataclass
+class Task:
+    id: int
+    title: str
+    description: str = ""
+    completed: bool = False
+    due_date: Optional[datetime] = None
+
+    def to_row(self) -> Dict[str, str]:
+        return {
+            "id": str(self.id),
+            "title": self.title,
+            "description": self.description,
+            "completed": str(int(self.completed)),
+            "due_date": self.due_date.isoformat() if self.due_date else ""
+        }
+
+    @staticmethod
+    def from_row(row: Dict[str, str]) -> 'Task':
+        due = row.get("due_date")
+        due_date = datetime.fromisoformat(due) if due else None
+        return Task(
+            id=int(row.get("id", 0)),
+            title=row.get("title", ""),
+            description=row.get("description", ""),
+            completed=row.get("completed", "0") in ("1", "True", "true"),
+            due_date=due_date,
+        )

--- a/todo/storage.py
+++ b/todo/storage.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import List, Iterable, Dict
+import csv
+from .models import Task
+
+class StorageInterface(ABC):
+    """Interface object defining contract for task storage."""
+
+    @abstractmethod
+    def load_tasks(self) -> List[Task]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def save_tasks(self, tasks: Iterable[Task]) -> None:
+        raise NotImplementedError
+
+class CSVStorage(StorageInterface):
+    """Base CSV storage implementing basic read/write."""
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+
+    def load_rows(self) -> List[Dict[str, str]]:
+        try:
+            with open(self.filename, newline="", encoding="utf-8") as f:
+                return list(csv.DictReader(f))
+        except FileNotFoundError:
+            return []
+
+    def save_rows(self, rows: Iterable[Dict[str, str]]) -> None:
+        fieldnames = ["id", "title", "description", "completed", "due_date"]
+        with open(self.filename, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+
+    # Implement interface methods
+    def load_tasks(self) -> List[Task]:
+        rows = self.load_rows()
+        return [Task.from_row(r) for r in rows]
+
+    def save_tasks(self, tasks: Iterable[Task]) -> None:
+        rows = [t.to_row() for t in tasks]
+        self.save_rows(rows)
+
+class CSVTaskStorage(CSVStorage):
+    """Specialized CSV storage for Tasks (multi-level inheritance example)."""
+    pass


### PR DESCRIPTION
## Summary
- add simple todo list application in Python
- implement storage using CSV files
- demonstrate inheritance, multi-level inheritance, and interface objects
- add CLI for adding, listing, filtering, and completing tasks
- update README with usage instructions

## Testing
- `python3 -m todo.cli list`
- `python3 -m todo.cli add "Buy milk" --description "2 liters" --due 2024-06-01T12:00:00`
- `python3 -m todo.cli filter --title-contains milk`
- `python3 -m todo.cli done 1`
