### PR TITLE
Fix mark_complete logic and add unit tests

### DIFF
--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,57 @@
+import os
+import tempfile
+import unittest
+from datetime import datetime
+
+from todo.manager import TodoManager
+from todo.storage import CSVTaskStorage
+
+
+def create_manager(tmpdir):
+    storage = CSVTaskStorage(os.path.join(tmpdir, "tasks.csv"))
+    manager = TodoManager(storage)
+    manager.load()
+    return manager
+
+
+class TodoManagerTests(unittest.TestCase):
+    def test_add_and_persist_task(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = create_manager(tmp)
+            manager.add_task("Test", description="desc", due_date=datetime(2023, 1, 1, 10, 0))
+            manager.save()
+
+            manager2 = TodoManager(CSVTaskStorage(os.path.join(tmp, "tasks.csv")))
+            manager2.load()
+
+            self.assertEqual(len(manager2.list_tasks()), 1)
+            t = manager2.list_tasks()[0]
+            self.assertEqual(t.title, "Test")
+            self.assertEqual(t.description, "desc")
+            self.assertEqual(t.due_date, datetime(2023, 1, 1, 10, 0))
+
+    def test_mark_complete_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = create_manager(tmp)
+            task = manager.add_task("Task")
+            self.assertTrue(manager.mark_complete(task.id))
+            self.assertTrue(manager.list_tasks()[0].completed)
+
+    def test_mark_complete_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = create_manager(tmp)
+            manager.add_task("Task")
+            self.assertFalse(manager.mark_complete(999))
+
+    def test_filter_completed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manager = create_manager(tmp)
+            t1 = manager.add_task("A")
+            t2 = manager.add_task("B")
+            manager.mark_complete(t2.id)
+            completed = manager.filter_tasks(lambda t: t.completed)
+            self.assertEqual([t.id for t in completed], [t2.id])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/todo/cli.py
+++ b/todo/cli.py
@@ -50,9 +50,11 @@ def main():
         for task in manager.filter_tasks(predicate):
             print(task)
     elif args.command == "done":
-        manager.mark_complete(args.task_id)
-        manager.save()
-        print("Task marked complete")
+        if manager.mark_complete(args.task_id):
+            manager.save()
+            print("Task marked complete")
+        else:
+            print("Task not found")
     else:
         print("No command specified")
 

--- a/todo/manager.py
+++ b/todo/manager.py
@@ -27,11 +27,16 @@ class TodoManager(Filterable):
         self.tasks.append(task)
         return task
 
-    def mark_complete(self, task_id: int) -> None:
+    def mark_complete(self, task_id: int) -> bool:
+        """Mark the task with ``task_id`` as completed.
+
+        Returns ``True`` if the task was found and updated, otherwise ``False``.
+        """
         for t in self.tasks:
             if t.id == task_id:
                 t.completed = True
-                break
+                return True
+        return False
 
     def filter_tasks(self, predicate: Callable[[Task], bool]) -> List[Task]:
         return [t for t in self.tasks if predicate(t)]


### PR DESCRIPTION
## Summary
- return a boolean from `mark_complete` to signal success
- print a message in the CLI if the task is missing
- add unit tests for `TodoManager`

## Testing
- `python3 -m unittest tests.test_manager -v`